### PR TITLE
docs: correct environment example filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,22 @@
 ## Instalasi
 ```sh
-$ git clone https://github.com/insomness/0Class.git
-$ cd 0class
-$ composer install
+git clone https://github.com/insomness/0Class.git
+cd 0class
+composer install
 Jika menggunakan vscode
-$ code .
+code .
 ```
 
 **Rename .env.example menjadi .env**
 ```sh
-$ php artisan key:generate
+php artisan key:generate
 ```
 **Setup Database**
 Buka file .env dan sesuaikan db values dengan db yang anda buat
 ```sh
-$ php artisan migrate
-$ php artisan db:seed
-$ php artisan storage:link
+php artisan migrate
+php artisan db:seed
+php artisan storage:link
 ```
 
 License

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Jika menggunakan vscode
 $ code .
 ```
 
-**Rename .env-example menjadi .env**
+**Rename .env.example menjadi .env**
 ```sh
 $ php artisan key:generate
 ```


### PR DESCRIPTION
## Summary
- fix README reference to the environment example file name

## Testing
- `composer install` *(fails: PHP version 8.4.11 not satisfied)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6896d6cbd2d0832398c110705ebfa7fe