### PR TITLE
test: assert homepage text

### DIFF
--- a/tests/Feature/ExampleTest.php
+++ b/tests/Feature/ExampleTest.php
@@ -17,5 +17,6 @@ class ExampleTest extends TestCase
         $response = $this->get('/');
 
         $response->assertStatus(200);
+        $response->assertSee('Belajar Tanpa Batas');
     }
 }


### PR DESCRIPTION
## Summary
- add assertion verifying home page tagline appears

## Testing
- `phpunit` *(fails: command not found)*
- `composer install` *(fails: project requires PHP ^7.2, container has PHP 8.4)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6896d6dd157c8323b2d8e8f68dbe9a5c